### PR TITLE
タスク操作のAPIの実装

### DIFF
--- a/app/Http/Controllers/Api/TaskController.php
+++ b/app/Http/Controllers/Api/TaskController.php
@@ -4,8 +4,63 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use App\Models\Task;
+use Illuminate\Support\Facades\Gate;
 
 class TaskController extends Controller
 {
-    //
+    /**
+     * 認証中のユーザーのタスク一覧を返す
+     */
+    public function index(Request $request)
+    {
+        return $request->user()->tasks()->latest()->get();
+    }
+
+    /**
+     * 新しいタスクを作成する
+     */
+    public function store(Request $request)
+    {
+
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+        ]);
+
+        $task = $request->user()->tasks()->create([
+            'title' => $validated['title'],
+        ]);
+
+        return response()->json($task, 201);
+    }
+
+    /**
+     * タスクの完了状態を更新する
+     */
+    public function update(Request $request, Task $task)
+    {
+        Gate::authorize('update', $task);  // ポリシーでユーザー確認
+
+        $validated = $request->validate([
+            'is_completed' => 'required|boolean',
+        ]);
+
+        $task->update([
+            'is_completed' => $validated['is_completed'],
+        ]);
+
+        return response()->json($task);
+    }
+
+    /**
+     * タスクを削除する
+     */
+    public function destroy(Request $request, Task $task)
+    {
+        Gate::authorize('delete', $task);
+
+        $task->delete();
+
+        return response()->json(['message' => 'task deleted']);
+    }
 }

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -6,5 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class Task extends Model
 {
-    //
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -6,6 +6,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class Task extends Model
 {
+    protected $fillable = [
+        'title',
+        'is_completed',
+    ];
+
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -45,4 +45,9 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    public function tasks()
+    {
+        return $this->hasMany(Task::class);
+    }
 }

--- a/app/Policies/TaskPolicy.php
+++ b/app/Policies/TaskPolicy.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Task;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class TaskPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Task $task): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Task $task): bool
+    {
+        return $task->user_id === $user->id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Task $task): bool
+    {
+        return $task->user_id === $user->id;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Task $task): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Task $task): bool
+    {
+        return false;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\Task;
+use App\Policies\TaskPolicy;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Gate;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        Gate::policy(Task::class, TaskPolicy::class);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -12,7 +13,11 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->group('api', [
+            EnsureFrontendRequestsAreStateful::class,
+            \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -14,8 +14,10 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->group('api', [
+            \Illuminate\Session\Middleware\StartSession::class,
+            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             EnsureFrontendRequestsAreStateful::class,
-            \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
+            // \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ]);
     })

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,6 +4,8 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Cache\RateLimiting\Limit;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -11,13 +13,18 @@ return Application::configure(basePath: dirname(__DIR__))
         api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
+        then: function () {
+            RateLimiter::for('api', function ($request) {
+                return Limit::perMinute(60)->by(optional($request->user())->id ?: $request->ip());
+            });
+        }
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->group('api', [
             \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             EnsureFrontendRequestsAreStateful::class,
-            // \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
+            \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ]);
     })

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,4 +2,5 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\AuthServiceProvider::class,
 ];

--- a/config/cors.php
+++ b/config/cors.php
@@ -19,7 +19,7 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => ['http://localhost'],
+    'allowed_origins' => ['http://localhost:3000'],
 
     'allowed_origins_patterns' => [],
 

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cross-Origin Resource Sharing (CORS) Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your settings for cross-origin resource sharing
+    | or "CORS". This determines what cross-origin operations may execute
+    | in web browsers. You are free to adjust these settings as needed.
+    |
+    | To learn more: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+    |
+    */
+
+    'paths' => ['api/*', 'sanctum/csrf-cookie', 'login', 'logout', 'register', 'user'],
+
+    'allowed_methods' => ['*'],
+
+    'allowed_origins' => ['http://localhost'],
+
+    'allowed_origins_patterns' => [],
+
+    'allowed_headers' => ['*'],
+
+    'exposed_headers' => [],
+
+    'max_age' => 0,
+
+    'supports_credentials' => true,
+
+];

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\TaskController;
 
-Route::middleware('auth:sanctum')->prefix('tasks')->group(function () {
+Route::middleware(['web', 'auth:sanctum'])->prefix('tasks')->group(function () {
     Route::get('/', [TaskController::class, 'index']);
     Route::post('/', [TaskController::class, 'store']);
     Route::put('/{task}', [TaskController::class, 'update']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\TaskController;
 
-Route::middleware(['web', 'auth:sanctum'])->prefix('tasks')->group(function () {
+Route::middleware(['web', 'auth:sanctum', 'throttle:api'])->prefix('tasks')->group(function () {
     Route::get('/', [TaskController::class, 'index']);
     Route::post('/', [TaskController::class, 'store']);
     Route::put('/{task}', [TaskController::class, 'update']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,10 @@ Route::get('/', function () {
     return view('welcome');
 });
 
+Route::get('/login', function () {
+    return view('welcome');
+})->name('login');
+
 Route::post('/register', [RegisterController::class, 'store']);
 Route::post('/login', [LoginController::class, 'store']);
 Route::middleware('web', 'auth:sanctum')->post('/logout', function (Request $request) {


### PR DESCRIPTION
ユーザーのログインまではできています。
タスク操作のコントローラーとポリシーを作成しました。
ルーティング一覧は `sail artisan route:list` で確認してください。
ルーティング `/api/tasks/*` にセッション認証を適用しました。
`withCredentials: true` を有効にするためにCORSを設定しました。
未認証時のリダイレクト先として `[GET]http://localhots:80/login` を設定しました。

問題点
apiの認証が通りません。具体的にはwelcomeページにリダイレクトされてしまいます。
web.phpはsession認証で、api.phpはtoken認証になっていたため、apiにもsession認証を適用しました。